### PR TITLE
Added authenticate filter.

### DIFF
--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -138,6 +138,38 @@ class OpenID_Connect_Generic_Client {
 	/**
 	 * Using the refresh token, request new tokens from the idp
 	 *
+	 * @param $username
+	 * @param $password
+	 *
+	 * @return array|\WP_Error
+	 */
+	function request_authentication_token_by_username_and_password($username, $password) {
+		$request = array(
+			'body' => array(
+				'grant_type'    => 'password',
+				'client_id'     => $this->client_id,
+				'client_secret' => $this->client_secret,
+				'username'      => $username,
+				'password'      => $password,
+				'scope'         => $this->scope,
+			),
+		);
+
+		// allow modifications to the request
+		$request = apply_filters('openid-connect-generic-alter-request', $request, 'get-authentication-token-by-username-and-password');
+
+		$response = wp_remote_post( $this->endpoint_token, $request );
+
+		if ( is_wp_error( $response ) ) {
+			$response->add( 'request_authentication_token' , __( 'Request for authentication token failed.' ) );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Using the refresh token, request new tokens from the idp
+	 *
 	 * @param $refresh_token - refresh token previously obtained from token response.
 	 *
 	 * @return array|\WP_Error
@@ -331,7 +363,7 @@ class OpenID_Connect_Generic_Client {
 			)
 			, true
 		);
-		
+
 		return $id_token_claim;
 	}
 
@@ -383,7 +415,7 @@ class OpenID_Connect_Generic_Client {
 	 * @param $user_claim
 	 * @param $id_token_claim
 	 *
-	 * @return \WP_Error
+	 * @return true|WP_Error
 	 */
 	function validate_user_claim( $user_claim, $id_token_claim ) {
 		// must be an array

--- a/includes/openid-connect-generic-option-settings.php
+++ b/includes/openid-connect-generic-option-settings.php
@@ -1,6 +1,32 @@
 <?php
 /**
  * Class OpenId_Connect_Generic_Option_Settings
+ *
+ * @property $login_type
+ * @property $client_id
+ * @property $client_secret
+ * @property $scope
+ * @property $endpoint_login
+ * @property $endpoint_userinfo
+ * @property $endpoint_token
+ * @property $endpoint_end_session
+ * @property $identity_key
+ * @property $no_sslverify
+ * @property $http_request_timeout
+ * @property $authenticate_filter
+ * @property $enforce_privacy
+ * @property $alternate_redirect_uri
+ * @property $nickname_key
+ * @property $email_format
+ * @property $displayname_format
+ * @property $identify_with_username
+ * @property $state_time_limit
+ * @property $link_existing_users
+ * @property $redirect_user_back
+ * @property $redirect_on_logout
+ * @property $enable_logging
+ * @property $log_limit
+ *
  */
 class OpenID_Connect_Generic_Option_Settings {
 	

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -116,6 +116,12 @@ class OpenID_Connect_Generic_Settings_Page {
 				'type'        => 'text',
 				'section'     => 'client_settings',
 			),
+			'authenticate_filter'   => array(
+				'title'       => __( 'Register authenticate filter' ),
+				'description' => __( 'Enables login by entering username and password on wordpress site without forwarding end user to OpenId server if allowed (grant_type: password).' ),
+				'type'        => 'checkbox',
+				'section'     => 'authorization_settings',
+			),
 			'enforce_privacy'   => array(
 				'title'       => __( 'Enforce Privacy' ),
 				'description' => __( 'Require users be logged in to see the site.' ),


### PR DESCRIPTION
If Identity Provider belongs to the same organisation there is no need to redirect end user to open-id server. It must be possible to login with username and password on wordpress site. 'Direct Access Grants aka grant_type=password' have to be enabled for client. This option is disabled by default.

made plugin to singleton. It would be good to have an access to settings without reading and parsing options.