### PR TITLE
Implement singleton pattern for OpenID_Connect_Generic class

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Global OIDCG functions.
+ *
+ * @package   OpenID_Connect_Generic
+ * @author    Jonathan Daggerhart <jonathan@daggerhart.com>
+ * @copyright 2015-2020 daggerhart
+ * @license   http://www.gnu.org/licenses/gpl-2.0.txt GPL-2.0+
+ */
+
+/**
+ * Return a single use authentication URL
+ */
+function oidcg_get_authentication_url() {
+	return \OpenID_Connect_Generic::instance()->client_wrapper->get_authentication_url();
+}

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -111,6 +111,13 @@ class OpenID_Connect_Generic {
 	private $client_wrapper;
 
 	/**
+	 * Singleton instance of self
+	 *
+	 * @var OpenID_Connect_Generic
+	 */
+	public static $instance;
+
+	/**
 	 * Setup the plugin
 	 *
 	 * @param OpenID_Connect_Generic_Option_Settings $settings The settings object.
@@ -121,6 +128,7 @@ class OpenID_Connect_Generic {
 	function __construct( OpenID_Connect_Generic_Option_Settings $settings, OpenID_Connect_Generic_Option_Logger $logger ) {
 		$this->settings = $settings;
 		$this->logger = $logger;
+		self::$instance = $this;
 	}
 
 	/**
@@ -368,9 +376,21 @@ class OpenID_Connect_Generic {
 		add_filter( 'the_excerpt_rss', array( $plugin, 'enforce_privacy_feeds' ), 999 );
 		add_filter( 'comment_text_rss', array( $plugin, 'enforce_privacy_feeds' ), 999 );
 	}
+
+	/**
+	 * Create (if needed) and return a singleton of self.
+	 *
+	 * @return OpenID_Connect_Generic
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::bootstrap();
+		}
+		return self::$instance;
+	}
 }
 
-OpenID_Connect_Generic::bootstrap();
+OpenID_Connect_Generic::instance();
 
 register_activation_hook( __FILE__, array( 'OpenID_Connect_Generic', 'activation' ) );
 register_deactivation_hook( __FILE__, array( 'OpenID_Connect_Generic', 'deactivation' ) );

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -392,5 +392,6 @@ class OpenID_Connect_Generic {
 
 OpenID_Connect_Generic::instance();
 
+require_once( 'includes/functions.php' );
 register_activation_hook( __FILE__, array( 'OpenID_Connect_Generic', 'activation' ) );
 register_deactivation_hook( __FILE__, array( 'OpenID_Connect_Generic', 'deactivation' ) );

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -108,7 +108,7 @@ class OpenID_Connect_Generic {
 	 *
 	 * @var OpenID_Connect_Generic_Client_Wrapper
 	 */
-	private $client_wrapper;
+	public $client_wrapper;
 
 	/**
 	 * Singleton instance of self


### PR DESCRIPTION
This will allow developers who want to be able to call methods belonging to this class (or methods belonging to any of this class's properties) to do so, without having to create a new instance, and therefore repeat all the bootstrapping.

Instead, they will just be able to call OpenID_Connect_Generic::get() to retrieve the singleton.