### PR TITLE
Fixes space/typo with Wiki link

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-Support.md
+++ b/.github/ISSUE_TEMPLATE/2-Support.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Review Wiki**
-Please be sure to check the [GitHub Wiki] (https://github.com/oidc-wp/openid-connect-generic/wiki)to see if your question has already been answered.
+Please be sure to check the [GitHub Wiki](https://github.com/oidc-wp/openid-connect-generic/wiki) to see if your question has already been answered.
 
 **General usage questions**
 If your question hasn't been answered in the Wiki please be as descriptive as possible when asking your question.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This fixes the Support Issue template to use correct spacing with the Wiki link.

### How to test the changes in this Pull Request:

1. Create a New Issues.
2. Select the Support Issue Type.
3. Confirm the text "GitHub Wiki" is a link to the repo wiki, when in preview mode.