### PR TITLE
Feature/backchannel logout

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -349,7 +349,6 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	 */
 	function authentication_request_callback() {
 		$client = $this->client;
-$this->logger->log("authxxxx");
 
 		// Start the authentication flow.
 		$authentication_request = $client->validate_authentication_request( $_GET );
@@ -480,7 +479,44 @@ $this->logger->log("authxxxx");
 	}
 
 	function backchannel_logout_request_callback( ) {
-		$this->logger->log( "Backchannel logout request received" );
+		$client = $this->client;
+
+		// This processes the OIDC Backchannel logout request. The request
+		// is made using the HTTP POST method. The function will fail if
+		// it is called from a request made with a HTTP method other than POST.
+		$request = $_POST;
+
+		if( $this->settings->keycloak_legacy_backchannel_logout_enable ) {
+			$this->logger->log( "FIXME: getting keycloak header not yet implemented" );
+		}
+
+$request_string = json_encode($request);
+$this->logger->log( "BCL request is: {$request_string}" );
+
+
+		// FIXME: token signature should be validated
+
+		$claims = $client->get_logout_token_claim( $request );
+		if ( is_wp_error( $claims ) ) {
+			$this->error_redirect( $claims );
+		}
+$this->logger->log( "BCL claims: {$claims}" );
+
+		// token needs to be validated:
+		// https://openid.net/specs/openid-connect-backchannel-1_0.html#rfc.section.2.6
+		// 
+		// FIXME: #1 and #2 (decryption and token signature) are not yet done here, 
+		// because we're lacking the necessary infrastructure. 
+		// The token introspection endpoint may be a viable alternative:
+		// https://tools.ietf.org/html/rfc7662
+		//
+
+		// Further validations in Section 2.6
+		$validation = $client->validate_logout_token_claim( $claims );
+		if( is_wp_error( $validation ) ) {
+			$this->error_redirect( $validation );
+		}
+
 		exit;
 	}
 

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -108,8 +108,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		if ( $settings->alternate_redirect_uri ) {
 			// Provide an alternate route for authentication_request_callback.
-			add_rewrite_rule( '^openid-connect-authorize/?', 'index.php?openid-connect-authorize=1', 'top' );
-			add_rewrite_tag( '%openid-connect-authorize%', '1' );
+				add_rewrite_rule( '^openid-connect-authorize/?', 'index.php?openid-connect-authorize=1', 'top' );
+				add_rewrite_tag( '%openid-connect-authorize%', '1' );
 			add_action( 'parse_request', array( $client_wrapper, 'alternate_redirect_uri_parse_request' ) );
 		}
 

--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -592,4 +592,15 @@ class OpenID_Connect_Generic_Client {
 		return $id_token_claim['sub'];
 	}
 
+	/**
+	 * Retrieve the session id from the token claims. This is the OpenID Providers's
+	 * session ID, it is not directly related to a wordpress session context.
+	 *
+	 * @param array $token_claims The token claims.
+	 *
+	 * @return mixed
+	 */
+	function get_session_id( $token_claims ) {
+		return $token_claims['sid'];
+	}
 }

--- a/includes/openid-connect-generic-option-settings.php
+++ b/includes/openid-connect-generic-option-settings.php
@@ -49,6 +49,7 @@
  *
  * @property bool $enforce_privacy          The flag to indicates whether a user us required to be authenticated to access the site.
  * @property bool $alternate_redirect_uri   The flag to indicate whether to use the alternative redirect URI.
+ * @property bool $keycloak_legacy_backchannel_logout_enable   The flag to enable Keycloak < v12.0.0 Backchannel Logout.
  * @property bool $token_refresh_enable     The flag whether to support refresh tokens by IDPs.
  * @property bool $link_existing_users      The flag to indicate whether to link to existing WordPress-only accounts or greturn an error.
  * @property bool $create_if_does_not_exist The flag to indicate whether to create new users or not.

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -304,6 +304,12 @@ class OpenID_Connect_Generic_Settings_Page {
 				'type'        => 'checkbox',
 				'section'     => 'authorization_settings',
 			),
+			'keycloak_legacy_backchannel_logout_enable'   => array(
+				'title'       => __( 'Support Keycloak Legacy Backchannel Logout (< v12.0.0)', 'daggerhart-openid-connect-generic' ),
+				'description' => __( 'Keycloak before version 12.0.0 only supports proprietary backchannel logout. This enables support for it by adding a specific route for it ("/keycloak/k_logout"). To enable it in a legacy keycloak, set the "Admin URL" on the client settings page in the Keycloak Admin Console to "<wordpress-url>/" (the root path). OIDC compliant backchannel logout is supported regardless whether this feature is enabled or not. You must flush rewrite rules after changing this setting. This can be done by saving the Permalinks settings page.', 'daggerhart-openid-connect-generic' ),
+				'type'        => 'checkbox',
+				'section'     => 'client_settings',
+			),
 			'nickname_key'     => array(
 				'title'       => __( 'Nickname Key', 'daggerhart-openid-connect-generic' ),
 				'description' => __( 'Where in the user claim array to find the user\'s nickname. Possible standard values: preferred_username, name, or sub.', 'daggerhart-openid-connect-generic' ),

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -346,6 +346,7 @@ class OpenID_Connect_Generic {
 				// Plugin settings.
 				'enforce_privacy' => 0,
 				'alternate_redirect_uri' => 0,
+				'keycloak_legacy_backchannel_logout_enable' => 0,
 				'token_refresh_enable' => 1,
 				'link_existing_users' => 0,
 				'create_if_does_not_exist' => 1,

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -55,6 +55,7 @@ Notes
 
   User Meta
   - openid-connect-generic-subject-identity    - the identity of the user provided by the idp
+  - openid-connect-generic-last-session-id     - the user's most recent IDP session ID if provided by the idp
   - openid-connect-generic-last-id-token-claim - the user's most recent id_token claim, decoded
   - openid-connect-generic-last-user-claim     - the user's most recent user_claim
   - openid-connect-generic-last-token-response - the user's most recent token response

--- a/readme.md
+++ b/readme.md
@@ -371,6 +371,7 @@ add_action('openid-connect-generic-redirect-user-back', function( $redirect_url,
 This plugin stores meta data about the user for both practical and debugging purposes.
 
 * `openid-connect-generic-subject-identity` - The identity of the user provided by the IDP server.
+* `openid-connect-generic-last-session-id` - The user's last IDP session ID if provided by the IDP server.
 * `openid-connect-generic-last-id-token-claim` - The user's most recent `id_token` claim, decoded and stored as an array.
 * `openid-connect-generic-last-user-claim` - The user's most recent `user_claim`, stored as an array.
 * `openid-connect-generic-last-token-response` - The user's most recent `token_response`, stored as an array.


### PR DESCRIPTION
### All Submissions:


* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Aims to implement OIDC Backchannel Logout and Keycloak legacy BCL feature.

Screnario: 
* User logs into Wordpress via OIDC's OP
* User then moves to other site, where she/he logs out of the OP, terminating all user sessions
* When user moves back to Wordpress, the user is expected to be logged out

This change implements the last point in the screnario; previously, the user remained logged in as long as the WP session itself didn't time out (which is quite long compared to an access_token lifetime in typical OIDC configurations). Not being logged out is particularly strange for users who, in an SSO context, log out of a running OP session and then log in with a different user. If WP does not recognize the logout, the WP session will keep running with the original user, which breaks the seamlessness promised in SSO contexts.

Closes #205 .

### How to test the changes in this Pull Request:

1. Connect against OIDC BCL compliant OP or Keycloak < 12.0.0 (tested in 4.8)
  * For OIDC BCL, set `https://my-wordpress-site.com/wp-admin/admin-ajax.php?action=openid-connect-backchannel-logout` as BCL URL in WP's client config
  * For Keycloak Legacy BCL, you need to enable it first on the settings page, then set `https://my-wordpress-site.com/` as the Admin URL in WP's client config
2. Login in WP using OIDC, change over to non WP-site. Logout from there, so that WP doesn't see the logout directly
3. Change back to WP
4. WP session should be logged out.

BCL logouts are logged via the logging feature.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
  -> Yes, in the Keycloak Legacy configuration, which is my main use case. I have no access to a BCL compliant OIDC provider

<!-- Mark completed items with an [x] -->

### Changelog entry

> Implement OpenID Connect Backchannel Logout
> Implement Keycloak Backchannel Logout (`k_logout`, for Keycloak before v12.0.0)
