### PR TITLE
Adding support for generic front logout channel

### DIFF
--- a/includes/openid-connect-generic-option-settings.php
+++ b/includes/openid-connect-generic-option-settings.php
@@ -31,6 +31,7 @@
  * @property string $scope                The list of scopes this client should access.
  * @property string $endpoint_login       The IDP authorization endpoint URL.
  * @property string $endpoint_userinfo    The IDP User information endpoint URL.
+ * @property string $endpoint_revoke      The IDP revoke endpoint URL.
  * @property string $endpoint_token       The IDP token validation endpoint URL.
  * @property string $endpoint_end_session The IDP logout endpoint URL.
  *
@@ -90,6 +91,7 @@ class OpenID_Connect_Generic_Option_Settings {
 		'client_secret'        => 'OIDC_CLIENT_SECRET',
 		'endpoint_login'       => 'OIDC_ENDPOINT_LOGIN_URL',
 		'endpoint_userinfo'    => 'OIDC_ENDPOINT_USERINFO_URL',
+		'endpoint_revoke'      => 'OIDC_ENDPOINT_REVOKE_URL',
 		'endpoint_token'       => 'OIDC_ENDPOINT_TOKEN_URL',
 		'endpoint_end_session' => 'OIDC_ENDPOINT_LOGOUT_URL',
 	);

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -256,6 +256,14 @@ class OpenID_Connect_Generic_Settings_Page {
 				'disabled'    => defined( 'OIDC_ENDPOINT_USERINFO_URL' ),
 				'section'     => 'client_settings',
 			),
+			'endpoint_revoke'    => array(
+				'title'       => __( 'Token Revocation Endpoint URL', 'daggerhart-openid-connect-generic' ),
+				'description' => __( 'Identify provider revoke endpoint.', 'daggerhart-openid-connect-generic' ),
+				'example'     => 'https://example.com/oauth2/revoke',
+				'type'        => 'text',
+				'disabled'    => defined( 'OIDC_ENDPOINT_REVOKE_URL' ),
+				'section'     => 'client_settings',
+			),
 			'endpoint_token'    => array(
 				'title'       => __( 'Token Validation Endpoint URL', 'daggerhart-openid-connect-generic' ),
 				'description' => __( 'Identify provider token endpoint.', 'daggerhart-openid-connect-generic' ),
@@ -414,9 +422,11 @@ class OpenID_Connect_Generic_Settings_Page {
 	 * @return void
 	 */
 	public function settings_page() {
+		$logout_uri = admin_url( 'admin-ajax.php?action=openid-connect-logout' );
 		$redirect_uri = admin_url( 'admin-ajax.php?action=openid-connect-authorize' );
 
 		if ( $this->settings->alternate_redirect_uri ) {
+			$logout_uri = site_url( '/openid-connect-logout' );
 			$redirect_uri = site_url( '/openid-connect-authorize' );
 		}
 		?>
@@ -441,6 +451,10 @@ class OpenID_Connect_Generic_Settings_Page {
 			<p class="description">
 				<strong><?php esc_html_e( 'Redirect URI', 'daggerhart-openid-connect-generic' ); ?></strong>
 				<code><?php print esc_url( $redirect_uri ); ?></code>
+			</p>
+			<p class="description">
+				<strong><?php esc_html_e( 'Logout URI', 'daggerhart-openid-connect-generic' ); ?></strong>
+				<code><?php print esc_url( $logout_uri ); ?></code>
 			</p>
 			<p class="description">
 				<strong><?php esc_html_e( 'Login Button Shortcode', 'daggerhart-openid-connect-generic' ); ?></strong>

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -132,9 +132,11 @@ class OpenID_Connect_Generic {
 
 		wp_enqueue_style( 'daggerhart-openid-connect-generic-admin', plugin_dir_url( __FILE__ ) . 'css/styles-admin.css', array(), self::VERSION, 'all' );
 
+		$logout_uri = admin_url( 'admin-ajax.php?action=openid-connect-logout' );
 		$redirect_uri = admin_url( 'admin-ajax.php?action=openid-connect-authorize' );
 
 		if ( $this->settings->alternate_redirect_uri ) {
+			$logout_uri = admin_url( '/openid-connect-logout' );
 			$redirect_uri = site_url( '/openid-connect-authorize' );
 		}
 
@@ -149,7 +151,9 @@ class OpenID_Connect_Generic {
 			$this->settings->scope,
 			$this->settings->endpoint_login,
 			$this->settings->endpoint_userinfo,
+			$this->settings->endpoint_revoke,
 			$this->settings->endpoint_token,
+			$logout_uri,
 			$redirect_uri,
 			$state_time_limit,
 			$this->logger
@@ -333,6 +337,7 @@ class OpenID_Connect_Generic {
 				'scope'                => '',
 				'endpoint_login'       => defined( 'OIDC_ENDPOINT_LOGIN_URL' ) ? OIDC_ENDPOINT_LOGIN_URL : '',
 				'endpoint_userinfo'    => defined( 'OIDC_ENDPOINT_USERINFO_URL' ) ? OIDC_ENDPOINT_USERINFO_URL : '',
+				'endpoint_revoke'      => defined( 'OIDC_ENDPOINT_REVOKE_URL' ) ? OIDC_ENDPOINT_REVOKE_URL : '',
 				'endpoint_token'       => defined( 'OIDC_ENDPOINT_TOKEN_URL' ) ? OIDC_ENDPOINT_TOKEN_URL : '',
 				'endpoint_end_session' => defined( 'OIDC_ENDPOINT_LOGOUT_URL' ) ? OIDC_ENDPOINT_LOGOUT_URL : '',
 

--- a/tests/phpstan-bootstrap.php
+++ b/tests/phpstan-bootstrap.php
@@ -21,5 +21,6 @@ defined( 'OIDC_CLIENT_ID' ) || define( 'OIDC_CLIENT_ID', bin2hex( random_bytes( 
 defined( 'OIDC_CLIENT_SECRET' ) || define( 'OIDC_CLIENT_SECRET', bin2hex( random_bytes( 16 ) ) );
 defined( 'OIDC_ENDPOINT_LOGIN_URL' ) || define( 'OIDC_ENDPOINT_LOGIN_URL', 'https://oidc/oauth2/authorize' );
 defined( 'OIDC_ENDPOINT_USERINFO_URL' ) || define( 'OIDC_ENDPOINT_USERINFO_URL', 'https://oidc/oauth2/userinfo' );
+defined( 'OIDC_ENDPOINT_REVOKE_URL' ) || define( 'OIDC_ENDPOINT_REVOKE_URL', 'https://oidc/oauth2/revoke' );
 defined( 'OIDC_ENDPOINT_TOKEN_URL' ) || define( 'OIDC_ENDPOINT_TOKEN_URL', 'https://oidc/oauth2/token' );
 defined( 'OIDC_ENDPOINT_LOGOUT_URL' ) || define( 'OIDC_ENDPOINT_LOGOUT_URL', 'https://oidc/oauth2/logout' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Implementing standard OpenID front logout channel as per https://openid.net/specs/openid-connect-frontchannel-1_0.html.

Closes #336 .

### How to test the changes in this Pull Request:

1. Fill the revoke endpoint in the settings of the plugin;
2. Do a GET on /wp-admin/admin-ajax.php?action=openid-connect-logout&sid=TOKEN_SID&iss=TOKEN_ISS with the browser of a connected user;
3. The user should be disconnected.

### Changelog entry
- Adding revoke OpenID endpoint in the settings;
- Adding openid-connect-logout endpoint to perform the front logout (iframe rendered by the client).
