### PR TITLE
Refresh user claim

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -589,7 +589,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	 * @param WP_User $user             The user object.
 	 * @param array   $token_response   The token response.
 	 *
-	 * @return void
+	 * @return WP_Error|array
 	 */
 	public function refresh_user_claim( $user, $token_response ) {
 		$client = $this->client;

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -122,6 +122,9 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			add_action( 'wp_loaded', array( $client_wrapper, 'ensure_tokens_still_fresh' ) );
 		}
 
+		// Add user claim refresh callable action.
+		add_action( 'openid-connect-generic-refresh-user-claim', array( $client_wrapper, 'refresh_user_claim' ), 10, 2 );
+
 		return $client_wrapper;
 	}
 
@@ -577,6 +580,65 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Refresh user claim.
+	 * Callable with do_action( 'openid-connect-generic-refresh-user-claim', $user, $token_response );
+	 *
+	 * @param WP_User $user             The user object.
+	 * @param array   $token_response   The token response.
+	 *
+	 * @return void
+	 */
+	public function refresh_user_claim( $user, $token_response ) {
+		$client = $this->client;
+
+		/**
+		 * The id_token is used to identify the authenticated user, e.g. for SSO.
+		 * The access_token must be used to prove access rights to protected
+		 * resources e.g. for the userinfo endpoint
+		 */
+		$id_token_claim = $client->get_id_token_claim( $token_response );
+
+		// Allow for other plugins to alter data before validation.
+		$id_token_claim = apply_filters( 'openid-connect-modify-id-token-claim-before-validation', $id_token_claim );
+
+		if ( is_wp_error( $id_token_claim ) ) {
+			return $id_token_claim;
+		}
+
+		// Validate our id_token has required values.
+		$valid = $client->validate_id_token_claim( $id_token_claim );
+
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		// If userinfo endpoint is set, exchange the token_response for a user_claim.
+		if ( ! empty( $this->settings->endpoint_userinfo ) && isset( $token_response['access_token'] ) ) {
+			$user_claim = $client->get_user_claim( $token_response );
+		} else {
+			$user_claim = $id_token_claim;
+		}
+
+		if ( is_wp_error( $user_claim ) ) {
+			return $user_claim;
+		}
+
+		// Validate our user_claim has required values.
+		$valid = $client->validate_user_claim( $user_claim, $id_token_claim );
+
+		if ( is_wp_error( $valid ) ) {
+			$this->error_redirect( $valid );
+			return $valid;
+		}
+
+		// Store the tokens for future reference.
+		update_user_meta( $user->ID, 'openid-connect-generic-last-id-token-claim', $id_token_claim );
+		update_user_meta( $user->ID, 'openid-connect-generic-last-user-claim', $user_claim );
+
+		return $user_claim;
 	}
 
 	/**

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -53,6 +53,9 @@ Notes
   - openid-connect-generic-state-not-found    - the given state does not exist in the database, regardless of its expiration.
   - openid-connect-generic-state-expired      - the given state exists, but expired before this login attempt.
 
+  Callable actions
+  - openid-connect-generic-refresh-user-claim - refresh user_claim, 2 args: WP_User, token response array
+
   User Meta
   - openid-connect-generic-subject-identity    - the identity of the user provided by the idp
   - openid-connect-generic-last-id-token-claim - the user's most recent id_token claim, decoded


### PR DESCRIPTION
Fix #339 
Address #122 

### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adding a new WP action to trigger user claim refresh.

### How to test the changes in this Pull Request:

1. Updates manually some attributes of your user
2. Checks that `$user->get('openid-connect-generic-last-user-claim')` contains outdated information
3. Calls 
```php
$user = wp_get_current_user();
$token_response = $user->get('openid-connect-generic-last-token-response');
do_action( 'openid-connect-generic-refresh-user-claim', $user, $token_response );
```
4. Checks that `$user->get('openid-connect-generic-last-user-claim')` contains updated information

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Adding a new WP action to trigger user claim refresh: `do_action( 'openid-connect-generic-refresh-user-claim', $user, $token_response )`
