### PR TITLE
Use site_url for the rewrite_rule when alternate_redirect_uri is true

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -112,7 +112,9 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		if ( $settings->alternate_redirect_uri ) {
 			// Provide an alternate route for authentication_request_callback.
-			add_rewrite_rule( '^openid-connect-authorize/?', 'index.php?openid-connect-authorize=1', 'top' );
+			$redirect_uri = site_url( '/openid-connect-authorize' );
+			$redirect_path = ltrim(parse_url($redirect_uri, PHP_URL_PATH), '/');
+			add_rewrite_rule( "^$redirect_path/?", 'index.php?openid-connect-authorize=1', 'top' );
 			add_rewrite_tag( '%openid-connect-authorize%', '1' );
 			add_action( 'parse_request', array( $client_wrapper, 'alternate_redirect_uri_parse_request' ) );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

For better consistency, use site_url for the rewrite_rule instead of hard-coding the path when alternate_redirect_uri is true.

The change is made primarily to fix a problem when WP_SITEURL is set to a subdirectory while alternate_redirect_uri is set to true.

### How to test the changes in this Pull Request:

1. Set `WP_SITEURL` to a subdirectory
2. Check the Alternate Redirect URI option in settings
3. Attempt a login with OpenID Connect

