### PR TITLE
Force refresh token

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -119,8 +119,11 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		// Verify token for any logged in user.
 		if ( is_user_logged_in() ) {
-			add_action( 'wp_loaded', array( $client_wrapper, 'ensure_tokens_still_fresh' ) );
+			add_action( 'wp_loaded', array( $client_wrapper, 'ensure_tokens_still_fresh_on_load' ) );
 		}
+
+		// Add token refresh callable action.
+		add_action( 'openid-connect-generic-refresh-token', array( $client_wrapper, 'force_refresh_token' ), 10, 0 );
 
 		// Add user claim refresh callable action.
 		add_action( 'openid-connect-generic-refresh-user-claim', array( $client_wrapper, 'refresh_user_claim' ), 10, 2 );
@@ -242,11 +245,21 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	}
 
 	/**
-	 * Handle retrieval and validation of refresh_token.
+	 * Handle refresh_token on wp_loaded.
 	 *
 	 * @return void
 	 */
-	public function ensure_tokens_still_fresh() {
+	public function ensure_tokens_still_fresh_on_load() {
+		$this->ensure_tokens_still_fresh(false);
+	}
+
+	/**
+	 * Handle retrieval and validation of refresh_token.
+	 *
+	 * @param bool $force
+	 * @return void
+	 */
+	public function ensure_tokens_still_fresh($force = false) {
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
@@ -266,7 +279,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		$next_access_token_refresh_time = $refresh_token_info['next_access_token_refresh_time'];
 
-		if ( $current_time < $next_access_token_refresh_time ) {
+		if ( !$force && $current_time < $next_access_token_refresh_time ) {
 			return;
 		}
 
@@ -299,6 +312,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		update_user_meta( $user_id, 'openid-connect-generic-last-token-response', $token_response );
 		$this->save_refresh_token( $manager, $token, $token_response );
+
+		do_action( 'openid-connect-generic-refresh-user-claim', wp_get_current_user(), $token_response );
 	}
 
 	/**
@@ -584,13 +599,29 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	}
 
 	/**
+	 * Force a token refresh.
+	 * Callable with do_action( 'openid-connect-generic-refresh-token', $user );
+	 *
+	 * @param WP_User $user             The user object.
+	 * @param array   $token_response   The token response.
+	 *
+	 * @return void
+	 */
+	public function force_refresh_token() {
+		$user = wp_get_current_user();
+		$this->ensure_tokens_still_fresh(true);
+		$token_response = $user->get('openid-connect-generic-last-token-response');
+		$this->refresh_user_claim($user, $token_response);
+	}
+
+	/**
 	 * Refresh user claim.
 	 * Callable with do_action( 'openid-connect-generic-refresh-user-claim', $user, $token_response );
 	 *
 	 * @param WP_User $user             The user object.
 	 * @param array   $token_response   The token response.
 	 *
-	 * @return WP_Error|array
+	 * @return void
 	 */
 	public function refresh_user_claim( $user, $token_response ) {
 		$client = $this->client;

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -53,6 +53,9 @@ Notes
   - openid-connect-generic-state-not-found    - the given state does not exist in the database, regardless of its expiration.
   - openid-connect-generic-state-expired      - the given state exists, but expired before this login attempt.
 
+  Callable actions
+  - openid-connect-generic-refresh-user-claim - refresh user_claim, 2 args: WP_User, token response array
+
   User Meta
   - openid-connect-generic-subject-identity    - the identity of the user provided by the idp
   - openid-connect-generic-last-id-token-claim - the user's most recent id_token claim, decoded


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add callable Wordpress action to force a token refresh:

```php
do_action( 'openid-connect-generic-refresh-token' );
```

### How to test the changes in this Pull Request:

1. Change user realm_access outside of wordpress
2. Check Wordpress what access_token realm_access contains (outdated informations)
3. Use the new action `do_action( 'openid-connect-generic-refresh-token' );`
4. Check Wordpress what access_token realm_access contains (refreshed informations)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

This PR contains also #338 (required to work). So, for both:

* Add new wordpress actions: `openid-connect-generic-refresh-token` and `openid-connect-generic-refresh-user-claim`
* Rewrite ensure_tokens_still_fresh to a protected method that handles bool param to force the refresh, no matter if time is expired
* After the token was refreshed, ensure that user claim is updated (by calling new `openid-connect-generic-refresh-user-claim` action)
