### PR TITLE
Acr value support 

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -214,6 +214,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 				'client_id' => $this->settings->client_id,
 				'redirect_uri' => $this->client->get_redirect_uri(),
 				'redirect_to' => $this->get_redirect_to(),
+				'acr_values' => $this->settings->acr_values,
 			),
 			$atts,
 			'openid_connect_generic_auth_url'
@@ -228,16 +229,29 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		if ( stripos( $this->settings->endpoint_login, '?' ) !== false ) {
 			$separator = '&';
 		}
-		$url = sprintf(
-			'%1$s%2$sresponse_type=code&scope=%3$s&client_id=%4$s&state=%5$s&redirect_uri=%6$s',
-			$atts['endpoint_login'],
-			$separator,
-			rawurlencode( $atts['scope'] ),
-			rawurlencode( $atts['client_id'] ),
-			$this->client->new_state( $atts['redirect_to'] ),
-			rawurlencode( $atts['redirect_uri'] )
-		);
-
+		if ( empty ( $this->settings->acr_values )) {
+		    $url = sprintf(
+			    '%1$s%2$sresponse_type=code&scope=%3$s&client_id=%4$s&state=%5$s&redirect_uri=%6$s',
+			    $atts['endpoint_login'],
+			    $separator,
+			    rawurlencode( $atts['scope'] ),
+			    rawurlencode( $atts['client_id'] ),
+			    $this->client->new_state( $atts['redirect_to'] ),
+			    rawurlencode( $atts['redirect_uri'] )
+			);
+		} else {
+			$url = sprintf(
+			    '%1$s%2$sresponse_type=code&scope=%3$s&client_id=%4$s&state=%5$s&redirect_uri=%6$s&acr_values=%7$s',
+			    $atts['endpoint_login'],
+			    $separator,
+			    rawurlencode( $atts['scope'] ),
+			    rawurlencode( $atts['client_id'] ),
+			    $this->client->new_state( $atts['redirect_to'] ),
+			    rawurlencode( $atts['redirect_uri'] ),
+			    rawurlencode( $atts['acr_values'] )
+			);
+		}
+	
 		$this->logger->log( apply_filters( 'openid-connect-generic-auth-url', $url ), 'make_authentication_url' );
 		return apply_filters( 'openid-connect-generic-auth-url', $url );
 	}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -229,7 +229,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		if ( stripos( $this->settings->endpoint_login, '?' ) !== false ) {
 			$separator = '&';
 		}
-		if ( empty ( $this->settings->acr_values )) {
+		if ( empty( $this->settings->acr_values ) ) {
 			$url = sprintf(
 				'%1$s%2$sresponse_type=code&scope=%3$s&client_id=%4$s&state=%5$s&redirect_uri=%6$s',
 				$atts['endpoint_login'],

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -230,28 +230,28 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			$separator = '&';
 		}
 		if ( empty ( $this->settings->acr_values )) {
-		    $url = sprintf(
-			    '%1$s%2$sresponse_type=code&scope=%3$s&client_id=%4$s&state=%5$s&redirect_uri=%6$s',
-			    $atts['endpoint_login'],
-			    $separator,
-			    rawurlencode( $atts['scope'] ),
-			    rawurlencode( $atts['client_id'] ),
-			    $this->client->new_state( $atts['redirect_to'] ),
-			    rawurlencode( $atts['redirect_uri'] )
+			$url = sprintf(
+				'%1$s%2$sresponse_type=code&scope=%3$s&client_id=%4$s&state=%5$s&redirect_uri=%6$s',
+				$atts['endpoint_login'],
+				$separator,
+				rawurlencode( $atts['scope'] ),
+				rawurlencode( $atts['client_id'] ),
+				$this->client->new_state( $atts['redirect_to'] ),
+				rawurlencode( $atts['redirect_uri'] )
 			);
 		} else {
 			$url = sprintf(
-			    '%1$s%2$sresponse_type=code&scope=%3$s&client_id=%4$s&state=%5$s&redirect_uri=%6$s&acr_values=%7$s',
-			    $atts['endpoint_login'],
-			    $separator,
-			    rawurlencode( $atts['scope'] ),
-			    rawurlencode( $atts['client_id'] ),
-			    $this->client->new_state( $atts['redirect_to'] ),
-			    rawurlencode( $atts['redirect_uri'] ),
-			    rawurlencode( $atts['acr_values'] )
+				'%1$s%2$sresponse_type=code&scope=%3$s&client_id=%4$s&state=%5$s&redirect_uri=%6$s&acr_values=%7$s',
+				$atts['endpoint_login'],
+				$separator,
+				rawurlencode( $atts['scope'] ),
+				rawurlencode( $atts['client_id'] ),
+				$this->client->new_state( $atts['redirect_to'] ),
+				rawurlencode( $atts['redirect_uri'] ),
+				rawurlencode( $atts['acr_values'] )
 			);
 		}
-	
+
 		$this->logger->log( apply_filters( 'openid-connect-generic-auth-url', $url ), 'make_authentication_url' );
 		return apply_filters( 'openid-connect-generic-auth-url', $url );
 	}

--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -223,8 +223,8 @@ class OpenID_Connect_Generic_Client {
 					'acr_values'    => $this->acr_values,
 				),
 			'headers' => array( 'Host' => $host ),
-		);
-			} else {
+			);
+		} else {
 			$request = array(
 				'body' => array(
 					'code'          => $code,

--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -212,16 +212,16 @@ class OpenID_Connect_Generic_Client {
 		$host = $parsed_url['host'];
 
 		if ( $this->acr_values ) {
-		$request = array(
-			'body' => array(
-				'code'          => $code,
-				'client_id'     => $this->client_id,
-				'client_secret' => $this->client_secret,
-				'redirect_uri'  => $this->redirect_uri,
-				'grant_type'    => 'authorization_code',
-				'scope'         => $this->scope,
+			$request = array(
+				'body' => array(
+					'code'          => $code,
+					'client_id'     => $this->client_id,
+					'client_secret' => $this->client_secret,
+					'redirect_uri'  => $this->redirect_uri,
+					'grant_type'    => 'authorization_code',
+					'scope'         => $this->scope,
 					'acr_values'    => $this->acr_values,
-			),
+				),
 			'headers' => array( 'Host' => $host ),
 		);
 			} else {

--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -222,7 +222,7 @@ class OpenID_Connect_Generic_Client {
 					'scope'         => $this->scope,
 					'acr_values'    => $this->acr_values,
 				),
-			'headers' => array( 'Host' => $host ),
+				'headers' => array( 'Host' => $host ),
 			);
 		} else {
 			$request = array(

--- a/includes/openid-connect-generic-option-settings.php
+++ b/includes/openid-connect-generic-option-settings.php
@@ -33,6 +33,7 @@
  * @property string $endpoint_userinfo    The IDP User information endpoint URL.
  * @property string $endpoint_token       The IDP token validation endpoint URL.
  * @property string $endpoint_end_session The IDP logout endpoint URL.
+ * @property string $acr_values           The Authentication contract as defined on the IDP.
  *
  * Non-standard Settings:
  *
@@ -99,6 +100,7 @@ class OpenID_Connect_Generic_Option_Settings {
 		'link_existing_users'       => 'OIDC_LINK_EXISTING_USERS',
 		'redirect_on_logout'        => 'OIDC_REDIRECT_ON_LOGOUT',
 		'redirect_user_back'        => 'OIDC_REDIRECT_USER_BACK',
+		'acr_values'                => 'OIDC_ACR_VALUES',
 	);
 
 	/**

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -274,6 +274,12 @@ class OpenID_Connect_Generic_Settings_Page {
 				'disabled'    => defined( 'OIDC_ENDPOINT_LOGOUT_URL' ),
 				'section'     => 'client_settings',
 			),
+			'acr_values'    => array(
+				'title'       => __( 'ACR values', 'daggerhart-openid-connect-generic' ),
+				'description' => __( 'Use a specific defined authentication contract from the IDP - optional.', 'daggerhart-openid-connect-generic' ),
+				'type'        => 'text',
+				'section'     => 'client_settings',
+			),			
 			'identity_key'     => array(
 				'title'       => __( 'Identity Key', 'daggerhart-openid-connect-generic' ),
 				'description' => __( 'Where in the user claim array to find the user\'s identification data. Possible standard values: preferred_username, name, or sub. If you\'re having trouble, use "sub".', 'daggerhart-openid-connect-generic' ),

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -279,7 +279,7 @@ class OpenID_Connect_Generic_Settings_Page {
 				'description' => __( 'Use a specific defined authentication contract from the IDP - optional.', 'daggerhart-openid-connect-generic' ),
 				'type'        => 'text',
 				'section'     => 'client_settings',
-			),			
+			),		
 			'identity_key'     => array(
 				'title'       => __( 'Identity Key', 'daggerhart-openid-connect-generic' ),
 				'description' => __( 'Where in the user claim array to find the user\'s identification data. Possible standard values: preferred_username, name, or sub. If you\'re having trouble, use "sub".', 'daggerhart-openid-connect-generic' ),

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -279,7 +279,7 @@ class OpenID_Connect_Generic_Settings_Page {
 				'description' => __( 'Use a specific defined authentication contract from the IDP - optional.', 'daggerhart-openid-connect-generic' ),
 				'type'        => 'text',
 				'section'     => 'client_settings',
-			),		
+			),
 			'identity_key'     => array(
 				'title'       => __( 'Identity Key', 'daggerhart-openid-connect-generic' ),
 				'description' => __( 'Where in the user claim array to find the user\'s identification data. Possible standard values: preferred_username, name, or sub. If you\'re having trouble, use "sub".', 'daggerhart-openid-connect-generic' ),

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -160,6 +160,7 @@ class OpenID_Connect_Generic {
 			$this->settings->endpoint_userinfo,
 			$this->settings->endpoint_token,
 			$redirect_uri,
+			$this->settings->acr_values,
 			$state_time_limit,
 			$this->logger
 		);
@@ -344,6 +345,7 @@ class OpenID_Connect_Generic {
 				'endpoint_userinfo'    => defined( 'OIDC_ENDPOINT_USERINFO_URL' ) ? OIDC_ENDPOINT_USERINFO_URL : '',
 				'endpoint_token'       => defined( 'OIDC_ENDPOINT_TOKEN_URL' ) ? OIDC_ENDPOINT_TOKEN_URL : '',
 				'endpoint_end_session' => defined( 'OIDC_ENDPOINT_LOGOUT_URL' ) ? OIDC_ENDPOINT_LOGOUT_URL : '',
+				'acr_values'           => defined( 'OIDC_ACR_VALUES' ) ? OIDC_ACR_VALUES : '',
 
 				// Non-standard settings.
 				'no_sslverify'    => 0,


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes #331 
This PR enhances the plugin with capabillities on handling acr_values - in which the request to the IDP includes a specific authentication contract as defined on the IDP.
Next to that enhancements have been made to also check - when set that the - if defined authentication contract is honored.


### How to test the changes in this Pull Request:

1. Define the added acr_values field option with a contract that exists on the IDP ie. urn:domain:contract:my_method_of_auth ( this is the exact name of the authentication uri as defined on a/the IDP.
2. Test login, and see that the added (acr_-)values to the url will influence the behaviour of the authentication contract with the IDP.
3. Verify manual url-manipulation check so it will error / disallow login ( remove the added acs_values from url manually and try it on your IDP)

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

- Added acr_values support & verification checks that it when defined in options is honored.
- 