### PR TITLE
Fixes 3.8.0 Regression for User Creation Failure When No Nickname

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/rermium
+lts/fermium

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -982,30 +982,30 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		// Allow claim details to determine username, email, nickname and displayname.
 		$_email = $this->get_email_from_claim( $user_claim, true );
-		if ( is_wp_error( $_email ) ) {
+		if ( is_wp_error( $_email ) || empty( $_email ) ) {
 			$values_missing = true;
-		} else if ( ! is_null( $_email ) ) {
+		} else {
 			$email = $_email;
 		}
 
 		$_username = $this->get_username_from_claim( $user_claim );
-		if ( is_wp_error( $_username ) ) {
+		if ( is_wp_error( $_username ) || empty( $_username ) ) {
 			$values_missing = true;
-		} else if ( ! empty( $_username ) ) {
+		} else {
 			$username = $_username;
 		}
 
 		$_nickname = $this->get_nickname_from_claim( $user_claim );
-		if ( is_null( $_nickname ) ) {
+		if ( is_wp_error( $_nickname ) || empty( $_nickname ) ) {
 			$values_missing = true;
 		} else {
 			$nickname = $_nickname;
 		}
 
 		$_displayname = $this->get_displayname_from_claim( $user_claim, true );
-		if ( is_wp_error( $_displayname ) ) {
+		if ( is_wp_error( $_displayname ) || empty( $_displayname ) ) {
 			$values_missing = true;
-		} else if ( ! is_null( $_displayname ) ) {
+		} else {
 			$displayname = $_displayname;
 		}
 
@@ -1024,28 +1024,36 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$_email = $this->get_email_from_claim( $user_claim, true );
 		if ( is_wp_error( $_email ) ) {
 			return $_email;
-		} else if ( ! is_null( $_email ) ) {
+		}
+		// Use the email address from the latest userinfo request if not empty.
+		if ( ! empty( $_email ) ) {
 			$email = $_email;
 		}
 
 		$_username = $this->get_username_from_claim( $user_claim );
 		if ( is_wp_error( $_username ) ) {
 			return $_username;
-		} else if ( ! empty( $_username ) ) {
+		}
+		// Use the username from the latest userinfo request if not empty.
+		if ( ! empty( $_username ) ) {
 			$username = $_username;
 		}
 
 		$_nickname = $this->get_nickname_from_claim( $user_claim );
 		if ( is_wp_error( $_nickname ) ) {
 			return $_nickname;
-		} else if ( is_null( $_nickname ) ) {
+		}
+		// Use the username as the nickname if the userinfo request nickname is empty.
+		if ( empty( $_nickname ) ) {
 			$nickname = $username;
 		}
 
 		$_displayname = $this->get_displayname_from_claim( $user_claim, true );
 		if ( is_wp_error( $_displayname ) ) {
 			return $_displayname;
-		} else if ( is_null( $_displayname ) ) {
+		}
+		// Use the nickname as the displayname if the userinfo request displayname is empty.
+		if ( empty( $_displayname ) ) {
 			$displayname = $nickname;
 		}
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Closes #243.
- Fixes the regression caused by the code changes in 3.8.0 which resulted in not performing proper fallbacks for missing cliams such as the nickname.

### How to test the changes in this Pull Request:

1. Setup OIDC plugin with an IDP that doesn't provide a nickname or set the nickname in the configuration to blank.
2. Confirm that user creation is successful with a fallback to using displayname.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

This fix addresses a regression is causes in release 3.8.0 that wouldn't allow the fallback to displayname to be used for the WordPress nickname if a nickname key wasn't provided by the IDP or configured in the settings.
