### PR TITLE
Refactors Callable Refresh User Claims Function & Action

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -9,8 +9,22 @@
  */
 
 /**
- * Return a single use authentication URL
+ * Return a single use authentication URL.
+ *
+ * @return string
  */
 function oidcg_get_authentication_url() {
 	return \OpenID_Connect_Generic::instance()->client_wrapper->get_authentication_url();
+}
+
+/**
+ * Refresh a user claim and update the user metadata.
+ *
+ * @param WP_User $user             The user object.
+ * @param array   $token_response   The token response.
+ *
+ * @return WP_Error|array
+ */
+function oidcg_refresh_user_claim( $user, $token_response ) {
+	return \OpenID_Connect_Generic::instance()->client_wrapper->refresh_user_claim( $user, $token_response );
 }

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -44,17 +44,16 @@ Notes
   - openid-connect-modify-id-token-claim-before-validation - modify the token claim before validation
 
   Actions
-  - openid-connect-generic-user-create        - 2 args: fires when a new user is created by this plugin
-  - openid-connect-generic-user-update        - 1 arg: user ID, fires when user is updated by this plugin
-  - openid-connect-generic-update-user-using-current-claim - 2 args: fires every time an existing user logs
-  - openid-connect-generic-redirect-user-back - 2 args: $redirect_url, $user. Allows interruption of redirect during login.
-  - openid-connect-generic-user-logged-in     - 1 arg: $user, fires when user is logged in.
-  - openid-connect-generic-cron-daily         - daily cron action
-  - openid-connect-generic-state-not-found    - the given state does not exist in the database, regardless of its expiration.
-  - openid-connect-generic-state-expired      - the given state exists, but expired before this login attempt.
+  - openid-connect-generic-user-create                     - 2 args: fires when a new user is created by this plugin
+  - openid-connect-generic-user-update                     - 1 arg: user ID, fires when user is updated by this plugin
+  - openid-connect-generic-update-user-using-current-claim - 2 args: fires every time an existing user logs in and the claims are updated.
+  - openid-connect-generic-redirect-user-back              - 2 args: $redirect_url, $user. Allows interruption of redirect during login.
+  - openid-connect-generic-user-logged-in                  - 1 arg: $user, fires when user is logged in.
+  - openid-connect-generic-cron-daily                      - daily cron action
+  - openid-connect-generic-state-not-found                 - the given state does not exist in the database, regardless of its expiration.
+  - openid-connect-generic-state-expired                   - the given state exists, but expired before this login attempt.
 
   Callable actions
-  - openid-connect-generic-refresh-user-claim - refresh user_claim, 2 args: WP_User, token response array
 
   User Meta
   - openid-connect-generic-subject-identity    - the identity of the user provided by the idp


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Refactors fix for #339

- Moves `openid-connect-generic-update-user-using-current-claim` action to within update user metadata during login.
- Adds a new publicly callable method that uses the plugin singleton.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
