### PR TITLE
fix(filters): Prevents running the auth url filter twice

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -243,8 +243,9 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			rawurlencode( $atts['acr_values'] )
 		);
 
-		$this->logger->log( apply_filters( 'openid-connect-generic-auth-url', $url ), 'make_authentication_url' );
-		return apply_filters( 'openid-connect-generic-auth-url', $url );
+		$url = apply_filters( 'openid-connect-generic-auth-url', $url );
+		$this->logger->log( $url, 'make_authentication_url' );
+		return $url;
 	}
 
 	/**


### PR DESCRIPTION
A small tweak to avoid running the whole filter twice (once for logging, and second time as a return value)