### PR TITLE
fix(tokens): Fixes the potential of deleting a working refresh_token when no new one is available

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -694,6 +694,17 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		if ( ! $this->settings->token_refresh_enable ) {
 			return;
 		}
+
+		/*
+			If the new token does not provide a new token, there are two case:
+			- The previous refresh token had no expiration date: Keep it
+			- The previous refresh token had an expiration date: Dunno
+			=> Do not override a working token. See #404
+		*/
+		if (!isset($token_response['refresh_token'])) {
+			return;
+		}
+
 		$session = $manager->get( $token );
 		$now = time();
 		$session[ $this->cookie_token_refresh_key ] = array(

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -701,7 +701,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			- The previous refresh token had an expiration date: Dunno
 			=> Do not override a working token. See #404
 		*/
-		if (!isset($token_response['refresh_token'])) {
+		if ( ! isset( $token_response['refresh_token'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`save_refresh_token()` disregard the existing and still valid `refresh_token` and replace it with false (since the response to a renewal does not contain it)

Closes #404

### How to test the changes in this Pull Request:

1. Use Google OIDC with refresh token
```php
        add_filter( 'openid-connect-generic-auth-url', function( string $url ) {
            return $url . '&access_type=offline&prompt=consent';
        });
```
2. Connect
3. See from your logs that, without this PR you're disconnect after 1h (the first call to`refresh_token`) 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?


### Changelog entry

Do not empty refresh_token if renewed access tokens do not come with new refresh_token.