### PR TITLE
userinfo endpoint is meant to be a GET request per the spec

### DIFF
--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -337,7 +337,7 @@ class OpenID_Connect_Generic_Client {
 
 		// Attempt the request including the access token in the query string for backwards compatibility.
 		$this->logger->log( $this->endpoint_userinfo, 'request_userinfo' );
-		$response = wp_remote_post( $this->endpoint_userinfo, $request );
+		$response = wp_remote_get( $this->endpoint_userinfo, $request );
 
 		if ( is_wp_error( $response ) ) {
 			$response->add( 'request_userinfo', __( 'Request for userinfo failed.', 'daggerhart-openid-connect-generic' ) );


### PR DESCRIPTION
Fixing a bug in the userinfo call. Userinfo is supposed to be called with a GET, not a POST:
https://connect2id.com/products/server/docs/api/userinfo#userinfo

### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixing a bug in the userinfo call. Userinfo is supposed to be called with a GET, not a POST:
https://connect2id.com/products/server/docs/api/userinfo#userinfo

Without it, our integration was receiving 'Invalid user claim.' consistently

Closes # .
#165 

### How to test the changes in this Pull Request:

1. Pull the change from my branch
2. Set up an Oauth connection (with token endpoint auth method set to Secret Post, if applicable for your IDP) 
3. Make sure your IDP supports a userinfo endpoint
4. Run through an auth flow. If it errors out with 'Invalid User Claim" then this fix was not implemented properly.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
