### PR TITLE
Add require_prompt as an option

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -211,6 +211,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 				'redirect_uri' => $this->client->get_redirect_uri(),
 				'redirect_to' => $this->get_redirect_to(),
 				'acr_values' => $this->settings->acr_values,
+				'prompt' => $this->settings->require_prompt ? 'login' : '',
 			),
 			$atts,
 			'openid_connect_generic_auth_url'
@@ -230,6 +231,9 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		if ( ! empty( $atts['acr_values'] ) ) {
 			$url_format .= '&acr_values=%7$s';
 		}
+		if ( ! empty( $atts['prompt'] ) ) {
+			$url_format .= '&prompt=%8$s';
+		}
 
 		$url = sprintf(
 			$url_format,
@@ -239,7 +243,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			rawurlencode( $atts['client_id'] ),
 			$this->client->new_state( $atts['redirect_to'] ),
 			rawurlencode( $atts['redirect_uri'] ),
-			rawurlencode( $atts['acr_values'] )
+			rawurlencode( $atts['acr_values'] ),
+			rawurlencode( $atts['prompt'] )
 		);
 
 		$url = apply_filters( 'openid-connect-generic-auth-url', $url );

--- a/includes/openid-connect-generic-option-settings.php
+++ b/includes/openid-connect-generic-option-settings.php
@@ -44,6 +44,7 @@
  * @property string $email_format           The key(s) in the user claim array to formulate the user's email address.
  * @property string $displayname_format     The key(s) in the user claim array to formulate the user's display name.
  * @property bool   $identify_with_username The flag which indicates how the user's identity will be determined.
+ * @property bool   $require_prompt			The flag which tells the IdP to show the login prompt every time.
  * @property int    $state_time_limit       The valid time limit of the state, in seconds. Defaults to 180 seconds.
  *
  * Plugin Settings:

--- a/includes/openid-connect-generic-option-settings.php
+++ b/includes/openid-connect-generic-option-settings.php
@@ -44,7 +44,7 @@
  * @property string $email_format           The key(s) in the user claim array to formulate the user's email address.
  * @property string $displayname_format     The key(s) in the user claim array to formulate the user's display name.
  * @property bool   $identify_with_username The flag which indicates how the user's identity will be determined.
- * @property bool   $require_prompt			The flag which tells the IdP to show the login prompt every time.
+ * @property bool   $require_prompt         The flag which tells the IdP to show the login prompt every time.
  * @property int    $state_time_limit       The valid time limit of the state, in seconds. Defaults to 180 seconds.
  *
  * Plugin Settings:

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -342,6 +342,12 @@ class OpenID_Connect_Generic_Settings_Page {
 				'type'        => 'checkbox',
 				'section'     => 'client_settings',
 			),
+			'require_prompt'  => array(
+				'title'       => __( 'Require Prompt', 'daggerhart-openid-connect-generic' ),
+				'description' => __( 'If checked, the IdP will always show the login prompt, regardless of whether the user used Remember Me.', 'daggerhart-openid-connect-generic' ),
+				'type'        => 'checkbox',
+				'section'     => 'client_settings',
+			),
 			'state_time_limit'     => array(
 				'title'       => __( 'State time limit', 'daggerhart-openid-connect-generic' ),
 				'description' => __( 'State valid time in seconds. Defaults to 180', 'daggerhart-openid-connect-generic' ),

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -356,6 +356,7 @@ class OpenID_Connect_Generic {
 				'email_format'       => '{email}',
 				'displayname_format' => '',
 				'identify_with_username' => false,
+				'require_prompt' => false,
 
 				// Plugin settings.
 				'enforce_privacy' => defined( 'OIDC_ENFORCE_PRIVACY' ) ? intval( OIDC_ENFORCE_PRIVACY ) : 0,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a "require_prompt" option in the settings. If enabled, it adds the prompt=login parameter to the authentication URL forcing the IdP to show the login form every time, regardless of whether the user checked "Remember Me".

### How to test the changes in this Pull Request:

1. Set Require Prompt to true in settings.
2. Check whether &prompt=login gets appended to the authentication URL.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Adds a "require_prompt" option in the settings. If enabled, it adds the prompt=login parameter to the authentication URL forcing the IdP to show the login form every time, regardless of whether the user checked "Remember Me".