### PR TITLE
feat(Sessions): Add remember me feature via a filter

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -670,7 +670,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		$remember_me = apply_filters( 'openid-connect-generic-remember-me', false, $user, $token_response, $id_token_claim, $user_claim, $subject_identity );
 		$expiration_days = $remember_me ? 14 : 2;
-		
+
 		// Create the WP session, so we know its token.
 		$expiration = time() + apply_filters( 'auth_cookie_expiration', $expiration_days * DAY_IN_SECONDS, $user->ID, false );
 		$manager = WP_Session_Tokens::get_instance( $user->ID );

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -668,8 +668,11 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		// Allow plugins / themes to take action using current claims on existing user (e.g. update role).
 		do_action( 'openid-connect-generic-update-user-using-current-claim', $user, $user_claim );
 
+		$remember_me = apply_filters( 'openid-connect-generic-remember-me', false, $user, $token_response, $id_token_claim, $user_claim, $subject_identity );
+		$expiration_days = $remember_me ? 14 : 2;
+		
 		// Create the WP session, so we know its token.
-		$expiration = time() + apply_filters( 'auth_cookie_expiration', 2 * DAY_IN_SECONDS, $user->ID, false );
+		$expiration = time() + apply_filters( 'auth_cookie_expiration', $expiration_days * DAY_IN_SECONDS, $user->ID, false );
 		$manager = WP_Session_Tokens::get_instance( $user->ID );
 		$token = $manager->create( $expiration );
 
@@ -677,7 +680,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$this->save_refresh_token( $manager, $token, $token_response );
 
 		// you did great, have a cookie!
-		wp_set_auth_cookie( $user->ID, false, '', $token );
+		wp_set_auth_cookie( $user->ID, $remember_me, '', $token );
 		do_action( 'wp_login', $user->user_login, $user );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/develop/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #512 .

This change allows the user to, using a filter, login users via the rememberme option in WordPress.
The wordpress login cookies will then be set for 14 days by default instead of two days as a session.

I originally wanted to use the token expiration date to do so, however this doesn't seem possible as you cannot pass an expiration date to the wp_set_auth_cookie function. So instead I chose to implement the remember me feature as used by WordPress itself.

What could maybe be possible is to dynamically add a filter for auth_cookie_expiration, so the WP user cookie expiration can be set to the same value. This filter needs to be added temporarily, and then removed.
However this is kind of hacky and i think it would be better to submit that as a separate PR after this one is approved.

### How to test the changes in this Pull Request:

1. In your theme, add `add_filter( 'openid-connect-generic-remember-me', '__return_true' );` to the functions.php file.
2. Login using the openid connect plugin
3. Open the development tools of your browser, and look at the cookie expiration. It should not be a session cookie, and it should be valid for 2 weeks.
![image](https://github.com/oidc-wp/openid-connect-generic/assets/50165380/dc730bdd-782a-4cb3-8755-f6182c61bcba)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added the `openid-connect-generic-remember-me` filter to allow theme makers to login users using the remember me option.
