### PR TITLE
feat(Cookies): Updates WP Cookie Expiration to Same as Session Length

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -684,7 +684,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		// openid token expiration.
 		if (
 			$remember_me
-			&& apply_filters( 'openid-connect-generic-use-token-expiration', false )
+			&& apply_filters( 'openid-connect-generic-use-token-refresh-expiration', false )
 			&& ( $token_response['refresh_expires_in'] ?? 0 )
 		) {
 			$this->openid_token_refresh_expires_in = $token_response['refresh_expires_in'];

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -670,7 +670,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		$remember_me = apply_filters( 'openid-connect-generic-remember-me', false, $user, $token_response, $id_token_claim, $user_claim, $subject_identity );
 		$expiration_days = $remember_me ? 14 : 2;
-		
+
 		// Create the WP session, so we know its token.
 		$expiration = time() + apply_filters( 'auth_cookie_expiration', $expiration_days * DAY_IN_SECONDS, $user->ID, false );
 		$manager = WP_Session_Tokens::get_instance( $user->ID );

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -679,9 +679,14 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$remember_me = apply_filters( 'openid-connect-generic-remember-me', false, $user, $token_response, $id_token_claim, $user_claim, $subject_identity );
 		$wp_expiration_days = $remember_me ? 14 : 2;
 
-		// If using token expiration is enabled, add a filter to overwrite the
-		// default cookie expiration with the openid token expiration.
-		if ( apply_filters( 'openid-connect-generic-use-token-expiration', false ) && ( $token_response['refresh_expires_in'] ?? 0 ) ) {
+		// If remember-me is enabled, and using token expiration is enabled,
+		// add a filter to overwrite the default cookie expiration with the
+		// openid token expiration.
+		if (
+			$remember_me
+			&& apply_filters( 'openid-connect-generic-use-token-expiration', false )
+			&& ( $token_response['refresh_expires_in'] ?? 0 )
+		) {
 			$this->openid_token_refresh_expires_in = $token_response['refresh_expires_in'];
 			add_filter( 'auth_cookie_expiration', array( $this, 'set_cookie_expiration_to_openid_token_refresh_expiration' ) );
 		}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -668,8 +668,11 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		// Allow plugins / themes to take action using current claims on existing user (e.g. update role).
 		do_action( 'openid-connect-generic-update-user-using-current-claim', $user, $user_claim );
 
+		$remember_me = apply_filters( 'openid-connect-generic-remember-me', false, $user, $token_response, $id_token_claim, $user_claim, $subject_identity );
+		$expiration_days = $remember_me ? 14 : 2;
+		
 		// Create the WP session, so we know its token.
-		$expiration = time() + apply_filters( 'auth_cookie_expiration', 2 * DAY_IN_SECONDS, $user->ID, false );
+		$expiration = time() + apply_filters( 'auth_cookie_expiration', $expiration_days * DAY_IN_SECONDS, $user->ID, false );
 		$manager = WP_Session_Tokens::get_instance( $user->ID );
 		$token = $manager->create( $expiration );
 
@@ -677,7 +680,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$this->save_refresh_token( $manager, $token, $token_response );
 
 		// you did great, have a cookie!
-		wp_set_auth_cookie( $user->ID, false, '', $token );
+		wp_set_auth_cookie( $user->ID, $remember_me, '', $token );
 		do_action( 'wp_login', $user->user_login, $user );
 	}
 

--- a/tests/phpunit/includes/openid-connect-generic-client-wrapper_test.php
+++ b/tests/phpunit/includes/openid-connect-generic-client-wrapper_test.php
@@ -103,7 +103,7 @@ class OpenID_Connect_Generic_Client_Wrapper_Test extends WP_UnitTestCase {
 
 		// Cleanup
 		remove_filter( 'openid-connect-generic-remember-me', '__return_true' );
-		remove_filter( 'openid-connect-generic-use-token-expiration', '__return_true' );
+		remove_filter( 'openid-connect-generic-use-token-refresh-expiration', '__return_true' );
 		$manager->destroy_all();
 		wp_clear_auth_cookie();
 	}

--- a/tests/phpunit/includes/openid-connect-generic-client-wrapper_test.php
+++ b/tests/phpunit/includes/openid-connect-generic-client-wrapper_test.php
@@ -45,6 +45,12 @@ class OpenID_Connect_Generic_Client_Wrapper_Test extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * Test if by using the remember-me filter, the user session expiration
+	 * is set to 14 days, which is the default of WordPress
+	 *
+	 * @group ClientWrapperTests
+	 */
 	public function test_plugin_client_wrapper_remember_me() {
 		// Set the remember me option to true
 		add_filter( 'openid-connect-generic-remember-me', '__return_true' );
@@ -52,19 +58,54 @@ class OpenID_Connect_Generic_Client_Wrapper_Test extends WP_UnitTestCase {
 		// Create a user and log in using the login function of the client wrapper
 		$user = $this->factory()->user->create_and_get( array( 'user_login' => 'test-remember-me-user' ) );
 		$this->client_wrapper->login_user( $user, array(
-			'expires_in' => 14 * HOUR_IN_SECONDS, // This does not influence the length of the cookie
+			'expires_in' => 5 * MINUTE_IN_SECONDS,
 		), array(), array(), '' );
 
 		// Retrieve the session tokens
 		$manager = WP_Session_Tokens::get_instance( $user->ID );
 		$token = $manager->get_all()[0];
 
-		// Assert if the token is set to expire in 14 days, with some seconds as a timing margin
+		// Assert if the token is set to expire in 14 days, with some timing margin
 		$this->assertGreaterThan( time() + 13 * DAY_IN_SECONDS, $token['expiration'] );
 		$this->assertLessThan( time() + 15 * DAY_IN_SECONDS, $token['expiration'] );
 
-		// Reset the remember me option
+		// Cleanup
 		remove_filter( 'openid-connect-generic-remember-me', '__return_true' );
+		$manager->destroy_all();
+		wp_clear_auth_cookie();
+	}
+
+	/**
+	 * Test if by using the use-token-expiration, the user session expiration
+	 * is set to the value of the expires_in parameter of the token.
+	 *
+	 * @group ClientWrapperTests
+	 */
+	public function test_plugin_client_wrapper_token_expiration() {
+		// Set the remember me option to true
+		add_filter( 'openid-connect-generic-remember-me', '__return_true' );
+		add_filter( 'openid-connect-generic-use-token-expiration', '__return_true' );
+
+		// Create a user and log in using the login function of the client wrapper
+		$user = $this->factory()->user->create_and_get( array( 'user_login' => 'test-remember-me-user' ) );
+		$this->client_wrapper->login_user( $user, array(
+			'expires_in' => 5 * MINUTE_IN_SECONDS,
+			'refresh_expires_in' => 30 * DAY_IN_SECONDS,
+		), array(), array(), '' );
+
+		// Retrieve the session tokens
+		$manager = WP_Session_Tokens::get_instance( $user->ID );
+		$token = $manager->get_all()[0];
+
+		// Assert if the token is set to expire in 30 days, with some timing margin
+		$this->assertGreaterThan( time() + 29 * DAY_IN_SECONDS, $token['expiration'] );
+		$this->assertLessThan( time() + 31 * DAY_IN_SECONDS, $token['expiration'] );
+
+		// Cleanup
+		remove_filter( 'openid-connect-generic-remember-me', '__return_true' );
+		remove_filter( 'openid-connect-generic-use-token-expiration', '__return_true' );
+		$manager->destroy_all();
+		wp_clear_auth_cookie();
 	}
 
 }

--- a/tests/phpunit/includes/openid-connect-generic-client-wrapper_test.php
+++ b/tests/phpunit/includes/openid-connect-generic-client-wrapper_test.php
@@ -84,7 +84,7 @@ class OpenID_Connect_Generic_Client_Wrapper_Test extends WP_UnitTestCase {
 	public function test_plugin_client_wrapper_token_expiration() {
 		// Set the remember me option to true
 		add_filter( 'openid-connect-generic-remember-me', '__return_true' );
-		add_filter( 'openid-connect-generic-use-token-expiration', '__return_true' );
+		add_filter( 'openid-connect-generic-use-token-refresh-expiration', '__return_true' );
 
 		// Create a user and log in using the login function of the client wrapper
 		$user = $this->factory()->user->create_and_get( array( 'user_login' => 'test-remember-me-user' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/develop/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #512 .

This change allows the user to, using a filter, make the WP user session length the same as the refresh token expiration.
So if a refresh token is valid for 30 days, the wordpress login cookies will then be set for 30 days instead of the default of 14 days. Please note that the remember-me option needs to be enabled as well, as wordpress does not allow changing the cookie expiration if remember-me is not used.

Please note that this PR requires the code of PR #513 , and also includes that code for now untill PR #513 is merged.

### How to test the changes in this Pull Request:

1. In your theme, add `add_filter( 'openid-connect-generic-remember-me', '__return_true' );` to the functions.php file.
2. In your theme, add `add_filter( 'openid-connect-generic-use-token-refresh-expiration', '__return_true' );` to the functions.php file.
3. Login using the openid connect plugin
4. Open the development tools of your browser, and look at the cookie expiration. It should not be a session cookie, and it should be valid for the same time as the refresh token of the IDP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added the `openid-connect-generic-use-token-refresh-expiration` filter to allow theme makers to login users with the same wp login cookie expiration time as the IDP.
