### PR TITLE
Add support for user sync for users created via wordpress

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -89,6 +89,7 @@ On the settings page for this plugin (Dashboard > Settings > OpenID Connect Gene
 - Link existing user: `OIDC_LINK_EXISTING_USERS` (boolean)
 - Redirect user back to origin page: `OIDC_REDIRECT_USER_BACK` (boolean)
 - Redirect on logout: `OIDC_REDIRECT_ON_LOGOUT` (boolean)
+- User sync endpoint (keycloak): `OIDC_ENDPOINT_USER_CREATION_URL`
 
 ## Hooks
 

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -246,6 +246,44 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	}
 
 	/**
+	 * Handle user creation and synchronization.
+	 * 
+	 * @param int   $user_id     The user ID.
+	 * @param array $user_claim  The user claim.
+	 * 
+	 * @return void
+	 */
+
+	public function handle_user_creation( $user_id, $user_claim ) {
+		$client = $this->client;
+		
+		// Get client token
+		$token_result  = $client->request_admin_client_token();;
+		if ( is_wp_error( $token_result ) ) {
+			error_log( print_r( $token_result, true ) );
+			return;
+		}
+
+		// Get the decoded response from the authentication request result.
+		$token_response = $client->get_token_response( $token_result );
+
+		$access_token = $token_response['access_token'];
+
+		$create_user_response = $client->create_oidc_user($access_token, $user_id, $user_claim);
+
+		if ( is_wp_error( $create_user_response ) ) {
+			error_log( print_r( $create_user_response, true ) );
+			return;
+
+		}
+		$set_password_response = $client->set_oidc_user_password($access_token, $user_claim['user_email'], $user_claim['user_pass']);
+
+		if ( is_wp_error( $set_password_response ) ) {
+			error_log( print_r( $set_password_response, true ) );
+		}
+	}
+
+	/**
 	 * Handle retrieval and validation of refresh_token.
 	 *
 	 * @return void

--- a/includes/openid-connect-generic-option-settings.php
+++ b/includes/openid-connect-generic-option-settings.php
@@ -25,15 +25,16 @@
  *
  * OAuth Client Settings:
  *
- * @property string $login_type           How the client (login form) should provide login options.
- * @property string $client_id            The ID the client will be recognized as when connecting the to Identity provider server.
- * @property string $client_secret        The secret key the IDP server expects from the client.
- * @property string $scope                The list of scopes this client should access.
- * @property string $endpoint_login       The IDP authorization endpoint URL.
- * @property string $endpoint_userinfo    The IDP User information endpoint URL.
- * @property string $endpoint_token       The IDP token validation endpoint URL.
- * @property string $endpoint_end_session The IDP logout endpoint URL.
- * @property string $acr_values           The Authentication contract as defined on the IDP.
+ * @property string $login_type            How the client (login form) should provide login options.
+ * @property string $client_id             The ID the client will be recognized as when connecting the to Identity provider server.
+ * @property string $client_secret         The secret key the IDP server expects from the client.
+ * @property string $scope                 The list of scopes this client should access.
+ * @property string $endpoint_login        The IDP authorization endpoint URL.
+ * @property string $endpoint_userinfo     The IDP User information endpoint URL.
+ * @property string $endpoint_usercreation The IDP User creation endpoint URL.
+ * @property string $endpoint_token        The IDP token validation endpoint URL.
+ * @property string $endpoint_end_session  The IDP logout endpoint URL.
+ * @property string $acr_values            The Authentication contract as defined on the IDP.
  *
  * Non-standard Settings:
  *
@@ -92,6 +93,7 @@ class OpenID_Connect_Generic_Option_Settings {
 		'endpoint_end_session'      => 'OIDC_ENDPOINT_LOGOUT_URL',
 		'endpoint_login'            => 'OIDC_ENDPOINT_LOGIN_URL',
 		'endpoint_token'            => 'OIDC_ENDPOINT_TOKEN_URL',
+		'endpoint_usercreation'     => 'OIDC_ENDPOINT_USER_CREATION_URL',
 		'endpoint_userinfo'         => 'OIDC_ENDPOINT_USERINFO_URL',
 		'login_type'                => 'OIDC_LOGIN_TYPE',
 		'scope'                     => 'OIDC_CLIENT_SCOPE',

--- a/includes/openid-connect-generic-settings-page.php
+++ b/includes/openid-connect-generic-settings-page.php
@@ -258,6 +258,14 @@ class OpenID_Connect_Generic_Settings_Page {
 				'disabled'    => defined( 'OIDC_ENDPOINT_USERINFO_URL' ),
 				'section'     => 'client_settings',
 			),
+			'endpoint_usercreation' => array(
+				'title'       => __( 'User creation Endpoint URL (optional)', 'daggerhart-openid-connect-generic' ),
+				'description' => __( 'Identify provider User creation endpoint. Leave empty, when not in use. Works with keycloak.', 'daggerhart-openid-connect-generic' ),
+				'example'     => '	http://keycloak:8080/admin/realms/test-realm/users',
+				'type'        => 'text',
+				'disabled'    => defined( 'OIDC_ENDPOINT_USER_CREATION_URL' ),
+				'section'     => 'client_settings',
+			),
 			'endpoint_token'    => array(
 				'title'       => __( 'Token Validation Endpoint URL', 'daggerhart-openid-connect-generic' ),
 				'description' => __( 'Identify provider token endpoint.', 'daggerhart-openid-connect-generic' ),

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -151,6 +151,7 @@ class OpenID_Connect_Generic {
 			$this->settings->endpoint_login,
 			$this->settings->endpoint_userinfo,
 			$this->settings->endpoint_token,
+			$this->settings->endpoint_usercreation,
 			$this->get_redirect_uri( $this->settings ),
 			$this->settings->acr_values,
 			$this->get_state_time_limit( $this->settings ),
@@ -169,6 +170,11 @@ class OpenID_Connect_Generic {
 
 		// Add actions to our scheduled cron jobs.
 		add_action( 'openid-connect-generic-cron-daily', array( $this, 'cron_states_garbage_collection' ) );
+
+		// Add a user creation hook.
+		if ( $this->settings->endpoint_usercreation!==''){
+			add_filter('user_register', array( $this->client_wrapper, 'handle_user_creation'), 10, 2);
+		}
 
 		$this->upgrade();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22153,6 +22153,11 @@
       "requires": {
         "semver": "~7.5.2",
         "shelljs": "^0.8.5"
+      },
+      "dependencies": {
+        "shelljs": {
+          "version": "^0.8.5"
+        }
       }
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -27655,6 +27660,11 @@
       "dev": true,
       "requires": {
         "shelljs": "^0.8.5"
+      },
+      "dependencies": {
+        "shelljs": {
+          "version": "^0.8.5"
+        }
       }
     },
     "grunt-checktextdomain": {
@@ -27794,6 +27804,9 @@
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw==",
           "dev": true
+        },
+        "getobject": {
+          "version": "^1.0.0"
         }
       }
     },
@@ -27848,6 +27861,9 @@
           "requires": {
             "isexe": "^2.0.0"
           }
+        },
+        "getobject": {
+          "version": "^1.0.0"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev-require": "^0.1.0"
   },
   "engines": {
-    "node": ">=14.0.0 <18",
+    "node": ">=14.0.0 <21",
     "npm": ">=6.0.0 <9"
   },
   "devDependencies": {


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/develop/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

My use case is, that when a user buys something via woocomerce and creates a user, the user should be synced to keycloak. Currently there is a Plugin [WordPress Single Sign-On SSO](https://wordpress.org/plugins/miniorange-login-with-eve-online-google-facebook/) that has in the 700$ tier this functionality. The problem is, it uses saml and not oidc and also i need to write custom theme hooks for elementor so i implemented this with openid-connect-generic.

Another use case would be to use event plugins that are creating users for event registrations etc.

I used the `user_register` filter and when no url is entered nothing happens. I used the keycloak [admin rest api](https://www.keycloak.org/docs-api/24.0.1/rest-api/index.html#_users_resource) for getting an access token, creating a user and setting a password.

If needed i can provide a minimal keycloak docker compose repo.

#### Room for improvements

Sync also metadata to keycloak or provide a function to do so.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #520 .

### How to test the changes in this Pull Request:

1. Setup keycloak, ensure that the client_id has the permission to create users
2. Set the `endpoint_usercreation` in the settings or via env var
3. Enable user registrations in wp
4. Register a user
5. Check if user is created in keycloak

or
4. set up woocomerce
5. checkout + create User account + enter a password

or 
4. add this code somewhere
```
		$username = 'test'. rand(0, 1000);
		$email = $username . '@test.com';
		$password = 'test';
		$user_id = wp_create_user( $username, $password, $email );
		if ( ! is_wp_error( $user_id ) ) {
			echo "User ID : ". $user_id;
			exit(0);
		}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
I didn't manage to get the test run.
```
daggerhart-openid-connect-generic$ yarn test
yarn run v1.22.10
$ npm run grunt test

> openid-connect-generic@3.9.1 grunt
> node_modules/.bin/grunt test

Running "checktextdomain:files" (checktextdomain) task

✔ No problems


Running "shell:phpunit" (shell) task
/bin/sh: 1: vendor/bin/phpunit: not found
Warning: Command failed: vendor/bin/phpunit
/bin/sh: 1: vendor/bin/phpunit: not found
 Use --force to continue.
```
This line in the pull request template has a typo
https://github.com/oidc-wp/openid-connect-generic/blob/develop/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L3C30-L3C59
And the https://github.com/oidc-wp/openid-connect-generic/wiki/How-to-setup-the-plugin-development-environment has wrong commands because `npm start` should be `npm run start`, but that doesn't exist either.
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Add support for user sync to keycloak for users created via wordpress/woocomerce

