### PR TITLE
fix(Wrapper): Fixes handling of optional `expires_in` attribute in Access Token

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,4 +26,4 @@ parameters:
     # Uses func_get_args()
     #- '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
     # Ignore cookie_redirect_key deprecation errors.
-    - '/^Access to deprecated property \$cookie_redirect_key/'
+    - '/^Fetching deprecated class constant COOKIE_REDIRECT_KEY of class OpenID_Connect_Generic_Client_Wrapper/'

--- a/tests/phpunit/includes/openid-connect-generic-client-wrapper_test.php
+++ b/tests/phpunit/includes/openid-connect-generic-client-wrapper_test.php
@@ -11,15 +11,29 @@
 class OpenID_Connect_Generic_Client_Wrapper_Test extends WP_UnitTestCase {
 
 	/**
+	 * @var OpenID_Connect_Generic_Client_Wrapper
+	 */
+	private $client_wrapper;
+
+	/**
+	 * @var WP_User_Meta_Session_Tokens
+	 */
+	private $manager;
+
+	/**
 	 * Test case setup method.
 	 *
 	 * @return void
 	 */
 	public function setUp(): void {
 
-		$this->client_wrapper = OpenID_Connect_Generic::instance()->client_wrapper;
-
 		parent::setUp();
+
+		remove_all_filters( 'session_token_manager' );
+		$user_id        = self::factory()->user->create();
+		$this->manager  = WP_Session_Tokens::get_instance( $user_id );
+
+		$this->client_wrapper = OpenID_Connect_Generic::instance()->client_wrapper;
 
 	}
 
@@ -29,6 +43,8 @@ class OpenID_Connect_Generic_Client_Wrapper_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function tearDown(): void {
+
+		unset( $this->client_wrapper );
 
 		parent::tearDown();
 
@@ -76,36 +92,27 @@ class OpenID_Connect_Generic_Client_Wrapper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test if by using the use-token-expiration, the user session expiration
-	 * is set to the value of the expires_in parameter of the token.
+	 * Test proper handling of saving refresh tokens.
 	 *
 	 * @group ClientWrapperTests
 	 */
-	public function test_plugin_client_wrapper_token_expiration() {
-		// Set the remember me option to true
-		add_filter( 'openid-connect-generic-remember-me', '__return_true' );
-		add_filter( 'openid-connect-generic-use-token-refresh-expiration', '__return_true' );
+	public function test_save_refresh_token() {
+		$expiration 				= time() + DAY_IN_SECONDS;
+		$token 							= $this->manager->create( $expiration );
+		$token_response 		= array(
+			"access_token"  => "TlBN45jURg",
+			"token_type"    => "Bearer",
+			"refresh_token" => "9yNOxJtZa5",
+			"expires_in"    => 3600, // Expiration time of the Access Token in seconds since the response was generated. OPTIONAL.
+		);
 
-		// Create a user and log in using the login function of the client wrapper
-		$user = $this->factory()->user->create_and_get( array( 'user_login' => 'test-remember-me-user' ) );
-		$this->client_wrapper->login_user( $user, array(
-			'expires_in' => 5 * MINUTE_IN_SECONDS,
-			'refresh_expires_in' => 30 * DAY_IN_SECONDS,
-		), array(), array(), '' );
+		$this->client_wrapper->save_refresh_token( $this->manager, $token, $token_response );
+		$session = $this->manager->get( $token );
 
-		// Retrieve the session tokens
-		$manager = WP_Session_Tokens::get_instance( $user->ID );
-		$token = $manager->get_all()[0];
+		$this->assertArrayHasKey( $this->client_wrapper::COOKIE_TOKEN_REFRESH_KEY, $session, "Session token is missing expected key!"	);
+		$this->assertArrayHasKey( 'refresh_token', $session[ $this->client_wrapper::COOKIE_TOKEN_REFRESH_KEY ], "Refresh token is missing key!" );
 
-		// Assert if the token is set to expire in 30 days, with some timing margin
-		$this->assertGreaterThan( time() + 29 * DAY_IN_SECONDS, $token['expiration'] );
-		$this->assertLessThan( time() + 31 * DAY_IN_SECONDS, $token['expiration'] );
-
-		// Cleanup
-		remove_filter( 'openid-connect-generic-remember-me', '__return_true' );
-		remove_filter( 'openid-connect-generic-use-token-refresh-expiration', '__return_true' );
-		$manager->destroy_all();
-		wp_clear_auth_cookie();
+		$this->manager->destroy( $token );
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/develop/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Fixes #439
- Properly handles `expires_in` being OPTIONAl according to spec. (See: 3.2.2.5.  Successful Authentication Response)

### How to test the changes in this Pull Request:

1. Review Unit Tests.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
